### PR TITLE
refactor: use updpkgsums to update shasums

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux
 
-RUN pacman --needed --noconfirm -Syu base base-devel git perl openssh
+RUN pacman --needed --noconfirm -Syu base base-devel pacman-contrib git openssh
 
 # Add non-root user
 RUN useradd -m builder && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ cd "$INPUT_PACKAGE_NAME"
 echo "Setting version: ${NEW_RELEASE}"
 sed -i "s/pkgver=.*$/pkgver=${NEW_RELEASE}/" PKGBUILD
 sed -i "s/pkgrel=.*$/pkgrel=1/" PKGBUILD
-perl -i -0pe "s/sha256sums=[\s\S][^\)]*\)/$(makepkg -g 2>/dev/null)/" PKGBUILD
+updpkgsums
 
 echo "::endgroup::Setup"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Use an already existing tool which is also suggested in the [wiki](https://wiki.archlinux.org/title/Makepkg#Generate_new_checksums) over a regular expression prone to issues.

<!-- Describe your changes in detail -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The tool worked fine for me so far and I ended up having an issue with the Perl regular expression.
Having a package with multiple architectures (`sha256sum_x86_64` for example) is not matched with this regular expression.
`sha512sums` wont be matched via this regex either.
Issues with the package are fixed upstream in the official repos rather than just within this GitHub action.

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

The tool is in use by me for some years now. I did not fully test the action itself with the change. I just checked the logic and checked if the container still builds (dependencies).
As this step is attempting to do what `updpkgsums` is successfully doing its a simple switch.

#### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
