### PR TITLE
feat: Provide custom version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   package_name:
     description: The name of the AUR package to update.
     required: true
+  package_version:
+    description: The version of the AUR package to publish.
+    required: false
+    default: ${{ github.ref_name }}
   commit_username:
     description: The username to use when creating the new commit.
     required: true
@@ -21,4 +25,4 @@ runs:
   using: docker
   image: Dockerfile
   args:
-    - ${{ inputs.package_name }} ${{ inputs.commit_username }} ${{ inputs.commit_email }} ${{ inputs.ssh_private_key }}
+    - ${{ inputs.package_name }} ${{ inputs.package_version }} ${{ inputs.commit_username }} ${{ inputs.commit_email }} ${{ inputs.ssh_private_key }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ ssh-keyscan aur.archlinux.org >> "${HOME}/.ssh/known_hosts"
 echo "Writing SSH Private keys to file"
 echo -e "${INPUT_SSH_PRIVATE_KEY//_/\\n}" > "${HOME}/.ssh/aur"
 
-chmod 600 "${HOME}/.ssh/aur*"
+chmod 600 "${HOME}"/.ssh/aur*
 
 echo "Setting up Git"
 git config --global user.name "${INPUT_COMMIT_USERNAME}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -o errexit -o pipefail -o nounset
 if [[ -z "${INPUT_VERSION}" ]]; then
   NEW_RELEASE=${GITHUB_REF##*/v}
 else
-  NEW_RELEASE=${INPUT_VERSION}
+  NEW_RELEASE=${INPUT_VERSION#v}
 fi
 
 export HOME=/home/builder

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2154
 
 set -o errexit -o pipefail -o nounset
 
@@ -9,23 +10,23 @@ export HOME=/home/builder
 echo "::group::Setup"
 
 echo "Getting AUR SSH Public keys"
-ssh-keyscan aur.archlinux.org >>$HOME/.ssh/known_hosts
+ssh-keyscan aur.archlinux.org >> "${HOME}/.ssh/known_hosts"
 
 echo "Writing SSH Private keys to file"
-echo -e "${INPUT_SSH_PRIVATE_KEY//_/\\n}" >$HOME/.ssh/aur
+echo -e "${INPUT_SSH_PRIVATE_KEY//_/\\n}" > "${HOME}/.ssh/aur"
 
-chmod 600 $HOME/.ssh/aur*
+chmod 600 "${HOME}/.ssh/aur*"
 
 echo "Setting up Git"
-git config --global user.name "$INPUT_COMMIT_USERNAME"
-git config --global user.email "$INPUT_COMMIT_EMAIL"
+git config --global user.name "${INPUT_COMMIT_USERNAME}"
+git config --global user.email "${INPUT_COMMIT_EMAIL}"
 
 REPO_URL="ssh://aur@aur.archlinux.org/${INPUT_PACKAGE_NAME}.git"
 
 echo "Cloning repo"
 cd /tmp
-git clone "$REPO_URL"
-cd "$INPUT_PACKAGE_NAME"
+git clone "${REPO_URL}"
+cd "${INPUT_PACKAGE_NAME}"
 
 echo "Setting version: ${NEW_RELEASE}"
 sed -i "s/pkgver=.*$/pkgver=${NEW_RELEASE}/" PKGBUILD
@@ -40,7 +41,7 @@ echo "Building and installing dependencies"
 makepkg --noconfirm -s -c
 
 echo "Updating SRCINFO"
-makepkg --printsrcinfo >.SRCINFO
+makepkg --printsrcinfo > .SRCINFO
 
 echo "::endgroup::Build"
 
@@ -49,7 +50,7 @@ echo "::group::Publish"
 echo "Publishing new version"
 # Update aur
 git add PKGBUILD .SRCINFO
-git commit --allow-empty -m "Update to $NEW_RELEASE"
+git commit --allow-empty -m "Update to ${NEW_RELEASE}"
 git push
 
 echo "Publish Done"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail -o nounset
 
-if [[ -z "${INPUT_VERSION}" ]]; then
-  NEW_RELEASE=${GITHUB_REF##*/v}
-else
-  NEW_RELEASE=${INPUT_VERSION#v}
-fi
+NEW_RELEASE="${INPUT_PACKAGE_VERSION#v}"
 
 export HOME=/home/builder
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,11 @@
 
 set -o errexit -o pipefail -o nounset
 
-NEW_RELEASE=${GITHUB_REF##*/v}
+if [[ -z "${INPUT_VERSION}" ]]; then
+  NEW_RELEASE=${GITHUB_REF##*/v}
+else
+  NEW_RELEASE=${INPUT_VERSION}
+fi
 
 export HOME=/home/builder
 


### PR DESCRIPTION
#### Description

Currently the `entrypoint.sh` file expects the version of the release stored in the environment variable `GITHUB_REF` (which is automatically set by the github actions runner).

To be able to provide a "custom" version to release, a new github actions input was added `package_version`.
By default, the old behavior is kept (taking `GITHUB.REF_NAME` as default value) but this can also be overwritten by setting the input explicitly.

#### Motivation and Context

This was/is wished by the community (see #2) and i also needed it for my publishing action, which can be triggered manually.
Thus it has no tag version set, but it is instead provided as an `input` to the workflow.

Closes #2

#### How Has This Been Tested

The modified version of this action is currently running on my repo [punktf](https://github.com/Shemnei/punktf) in the [publishing workflow](https://github.com/Shemnei/punktf/blob/main/.github/workflows/publish.yaml).

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Attributions & Thanks

This pr is mostly based on the work of [JustSimplyKyle](https://github.com/JustSimplyKyle) and his [fork](https://github.com/JustSimplyKyle/upgrade-aur-package).